### PR TITLE
feat: add alert aggregation service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 .buildlog/
 .history
 
+# Node backend
+backend/node_modules/
+backend/package-lock.json
+backend/dist/
+
 
 
 # Flutter repo-specific

--- a/README.md
+++ b/README.md
@@ -47,3 +47,25 @@ This repository is a monorepo containing the mobile app and the backend server.
 - **/mobile/**: Contains the Flutter mobile application.
 - **/backend/**: Contains the Node.js/TypeScript backend services.
 - **/docs/**: Contains project documentation.
+
+## Development
+
+### Backend
+
+```bash
+cd backend
+npm install
+npm run start
+```
+
+The API exposes a `/alerts` endpoint which accepts optional `county` and `severity` query parameters for filtering.
+
+### Data Sources
+
+The backend retrieves information from a number of official Swedish services:
+
+- **Polisen events** – https://polisen.se/api/events
+- **SMHI impact-based warnings** – https://opendata-download-warnings.smhi.se/api/category/severe-weather/version/2/warning.json
+- **Krisinformation** – https://api.krisinformation.se/v3/news and https://api.krisinformation.se/v3/vmas
+- **SCB PxWeb** – region lists (county and municipality codes/names)
+- **County Administrative Boards ArcGIS** – GeoJSON polygons for counties and municipalities

--- a/backend/src/adapters/arcgis.ts
+++ b/backend/src/adapters/arcgis.ts
@@ -1,5 +1,21 @@
-// This file will contain the adapter for fetching region geometry data (GeoJSON) from the County Admin Boards' ArcGIS server.
-//
-// API Endpoint: To be researched.
-//
-// The goal is to fetch GeoJSON polygons for all counties and municipalities.
+import { request } from 'undici';
+
+/**
+ * Fetch GeoJSON polygons for all municipalities.
+ */
+export async function fetchMunicipalityPolygons(): Promise<any> {
+  const { body } = await request(
+    'https://ext-geodata.lansstyrelsen.se/arcgis/rest/services/lsb/Kommuner/MapServer/1/query?where=1=1&outFields=KOMMUNNAMN,KOMMUNKOD,LANSKOD&outSR=4326&f=geojson'
+  );
+  return body.json();
+}
+
+/**
+ * Fetch GeoJSON polygons for all counties.
+ */
+export async function fetchCountyPolygons(): Promise<any> {
+  const { body } = await request(
+    'https://ext-geodata.lansstyrelsen.se/arcgis/rest/services/lsb/Lan/MapServer/2/query?where=1=1&outFields=LANSNAMN,LAN_KOD,LANSKOD&outSR=4326&f=geojson'
+  );
+  return body.json();
+}

--- a/backend/src/adapters/krisinformation.ts
+++ b/backend/src/adapters/krisinformation.ts
@@ -1,16 +1,39 @@
-// This file will contain the adapter for fetching and normalizing data from the Krisinformation v3 API.
-//
-// API Host: api.krisinformation.se
-// Endpoints: /v3/news, /v3/vmas
-//
-// Normalized structure:
-// {
-//   source: 'krisinfo',
-//   id: string,
-//   headline: string,
-//   preamble: string,
-//   counties: string[],
-//   publishedAt: Date,
-//   url: string,
-//   pushMessage?: string
-// }
+import { request } from 'undici';
+
+export interface KrisinformationItem {
+  source: 'krisinfo';
+  id: string;
+  headline: string;
+  preamble: string;
+  counties: string[];
+  publishedAt: Date;
+  url: string;
+  pushMessage?: string;
+}
+
+async function fetchEndpoint(endpoint: string, counties?: string[]): Promise<any[]> {
+  const qs = counties && counties.length ? `?counties=${counties.join(',')}` : '';
+  const { body } = await request(`https://api.krisinformation.se/v3/${endpoint}${qs}`);
+  return (await body.json()) as any[];
+}
+
+/**
+ * Fetches and normalizes news and VMAS alerts from the Krisinformation API.
+ */
+export async function fetchKrisinformationItems(counties?: string[]): Promise<KrisinformationItem[]> {
+  const [news, vmas] = await Promise.all([
+    fetchEndpoint('news', counties),
+    fetchEndpoint('vmas', counties),
+  ]);
+  const normalize = (item: any): KrisinformationItem => ({
+    source: 'krisinfo',
+    id: item.id,
+    headline: item.headline ?? item.title ?? '',
+    preamble: item.preamble ?? '',
+    counties: item.counties ?? [],
+    publishedAt: new Date(item.published ?? item.date),
+    url: item.web ?? item.url ?? '',
+    pushMessage: item.pushMessage,
+  });
+  return [...news, ...vmas].map(normalize);
+}

--- a/backend/src/adapters/polisen.ts
+++ b/backend/src/adapters/polisen.ts
@@ -1,19 +1,47 @@
-// This file will contain the adapter for fetching and normalizing data from the Polisen events API.
-//
-// API Endpoint: https://polisen.se/api/events
-//
-// Normalized structure:
-// {
-//   source: 'polisen',
-//   id: string,
-//   title: string,
-//   type: string,
-//   summary: string,
-//   url: string,
-//   occurredAt: Date,
-//   location: {
-//     name: string,
-//     lat: number,
-//     lon: number
-//   }
-// }
+import { request } from 'undici';
+
+export interface PolisenEvent {
+  source: 'polisen';
+  id: string;
+  title: string;
+  type: string;
+  summary: string;
+  url: string;
+  occurredAt: Date;
+  location: {
+    name: string;
+    lat: number | null;
+    lon: number | null;
+  };
+}
+
+/**
+ * Fetches and normalizes police events from the public Polisen API.
+ */
+export async function fetchPolisenEvents(): Promise<PolisenEvent[]> {
+  const { body } = await request('https://polisen.se/api/events');
+  const events = (await body.json()) as any[];
+  return events.map((e: any) => {
+    let lat: number | null = null;
+    let lon: number | null = null;
+    if (typeof e.location?.gps === 'string') {
+      const [latStr, lonStr] = e.location.gps.split(',').map((s: string) => s.trim());
+      lat = Number(latStr);
+      lon = Number(lonStr);
+    }
+    return {
+      source: 'polisen',
+      id: String(e.id ?? e.eventid),
+      title: e.name ?? '',
+      type: e.type ?? '',
+      summary: e.summary ?? '',
+      url: e.url ?? `https://polisen.se/aktuellt/handelser/${e.id ?? ''}`,
+      occurredAt: new Date(e.datetime),
+      location: {
+        name: e.location?.name ?? '',
+        lat,
+        lon,
+      },
+    };
+  });
+}

--- a/backend/src/adapters/scb.ts
+++ b/backend/src/adapters/scb.ts
@@ -1,5 +1,31 @@
-// This file will contain the adapter for fetching region data (counties and municipalities) from the SCB PxWeb API.
-//
-// API Endpoint: To be researched.
-//
-// The goal is to fetch a list of all 21 counties and 290 municipalities with their names and codes.
+import { request } from 'undici';
+
+export interface Region {
+  code: string;
+  name: string;
+}
+
+export interface RegionLists {
+  counties: Region[];
+  municipalities: Region[];
+}
+
+/**
+ * Fetches county and municipality codes/names from the SCB PxWeb API.
+ */
+export async function fetchRegionLists(): Promise<RegionLists> {
+  // Any PxWeb table exposing the Region variable works. This one contains both
+  // county (two-digit) and municipality (four-digit) codes.
+  const { body } = await request(
+    'https://api.scb.se/OV0104/v1/AM/AM0101/Population/'
+  );
+  const meta = (await body.json()) as any;
+  const regionVar = meta.variables.find((v: any) => v.code === 'Region');
+  const codes: string[] = regionVar.values;
+  const names: string[] = regionVar.valueTexts;
+  const entries = codes.map((code, i) => ({ code, name: names[i] }));
+  return {
+    counties: entries.filter((e) => e.code.length === 2),
+    municipalities: entries.filter((e) => e.code.length === 4),
+  };
+}

--- a/backend/src/adapters/smhi.ts
+++ b/backend/src/adapters/smhi.ts
@@ -1,16 +1,35 @@
-// This file will contain the adapter for fetching and normalizing data from the SMHI warnings API.
-//
-// API Endpoint: To be researched. Expected to be a JSON feed derived from CAP.
-//
-// Normalized structure:
-// {
-//   source: 'smhi',
-//   id: string,
-//   eventType: string,
-//   level: 'yellow' | 'orange' | 'red',
-//   description: string,
-//   areas: string[],
-//   validFrom: Date,
-//   validTo: Date,
-//   url: string
-// }
+import { request } from 'undici';
+
+export interface SmhiWarning {
+  source: 'smhi';
+  id: string;
+  eventType: string;
+  level: 'yellow' | 'orange' | 'red';
+  description: string;
+  areas: string[];
+  validFrom: Date;
+  validTo: Date;
+  url: string;
+}
+
+/**
+ * Fetches impact-based weather warnings from the SMHI API and normalizes them.
+ */
+export async function fetchSmhiWarnings(): Promise<SmhiWarning[]> {
+  const { body } = await request(
+    'https://opendata-download-warnings.smhi.se/api/category/severe-weather/version/2/warning.json'
+  );
+  const data = (await body.json()) as any;
+  const warnings = data?.warnings ?? [];
+  return warnings.map((w: any) => ({
+    source: 'smhi',
+    id: w.id ?? w.identifier,
+    eventType: w.event ?? w.title ?? '',
+    level: (w.level ?? w.severity ?? '').toLowerCase(),
+    description: w.description ?? '',
+    areas: (w.areas ?? []).map((a: any) => a.area ?? a.name ?? a),
+    validFrom: new Date(w.start ?? w.validFrom ?? w.from),
+    validTo: new Date(w.end ?? w.validTo ?? w.to),
+    url: w.urls?.[0]?.url ?? w.url ?? '',
+  }));
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,43 @@
+import Fastify from 'fastify';
+import { z } from 'zod';
+import { fetchAllAlerts } from './services/aggregator';
+import { Severity } from './models/alert';
+
+const app = Fastify();
+
+const querySchema = z.object({
+  county: z.string().optional(),
+  severity: z.enum(['info', 'low', 'medium', 'high']).optional(),
+});
+
+const severityOrder: Severity[] = ['info', 'low', 'medium', 'high'];
+
+app.get('/alerts', async (request, reply) => {
+  const { county, severity } = querySchema.parse(request.query);
+  const alerts = await fetchAllAlerts();
+  let filtered = alerts;
+  if (county) {
+    filtered = filtered.filter((a) => a.areas.includes(county));
+  }
+  if (severity) {
+    const threshold = severityOrder.indexOf(severity);
+    filtered = filtered.filter(
+      (a) => severityOrder.indexOf(a.severity) >= threshold
+    );
+  }
+  return filtered;
+});
+
+export async function start() {
+  try {
+    await app.listen({ port: Number(process.env.PORT) || 3000, host: '0.0.0.0' });
+    console.log('Server listening');
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  start();
+}

--- a/backend/src/models/alert.ts
+++ b/backend/src/models/alert.ts
@@ -1,0 +1,14 @@
+export type AlertSource = 'polisen' | 'smhi' | 'krisinformation';
+
+export type Severity = 'info' | 'low' | 'medium' | 'high';
+
+export interface Alert {
+  source: AlertSource;
+  id: string;
+  headline: string;
+  description?: string;
+  areas: string[];
+  severity: Severity;
+  publishedAt: Date;
+  url: string;
+}

--- a/backend/src/services/aggregator.ts
+++ b/backend/src/services/aggregator.ts
@@ -1,0 +1,63 @@
+import { Alert, Severity } from '../models/alert';
+import { fetchPolisenEvents } from '../adapters/polisen';
+import { fetchSmhiWarnings } from '../adapters/smhi';
+import { fetchKrisinformationItems } from '../adapters/krisinformation';
+
+function levelToSeverity(level: string): Severity {
+  switch (level) {
+    case 'red':
+      return 'high';
+    case 'orange':
+      return 'medium';
+    case 'yellow':
+      return 'low';
+    default:
+      return 'info';
+  }
+}
+
+/**
+ * Fetch alerts from all sources and return a combined, sorted list.
+ */
+export async function fetchAllAlerts(): Promise<Alert[]> {
+  const [polisenEvents, smhiWarnings, krisItems] = await Promise.all([
+    fetchPolisenEvents(),
+    fetchSmhiWarnings(),
+    fetchKrisinformationItems(),
+  ]);
+
+  const alerts: Alert[] = [
+    ...polisenEvents.map<Alert>((e) => ({
+      source: 'polisen',
+      id: e.id,
+      headline: e.title,
+      description: e.summary,
+      areas: e.location.name ? [e.location.name] : [],
+      severity: 'info',
+      publishedAt: e.occurredAt,
+      url: e.url,
+    })),
+    ...smhiWarnings.map<Alert>((w) => ({
+      source: 'smhi',
+      id: w.id,
+      headline: w.eventType,
+      description: w.description,
+      areas: w.areas,
+      severity: levelToSeverity(w.level),
+      publishedAt: w.validFrom,
+      url: w.url,
+    })),
+    ...krisItems.map<Alert>((k) => ({
+      source: 'krisinformation',
+      id: k.id,
+      headline: k.headline,
+      description: k.preamble,
+      areas: k.counties,
+      severity: 'info',
+      publishedAt: k.publishedAt,
+      url: k.url,
+    })),
+  ];
+
+  return alerts.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+}

--- a/backend/src/services/notification.ts
+++ b/backend/src/services/notification.ts
@@ -1,0 +1,25 @@
+import admin from 'firebase-admin';
+import { Alert } from '../models/alert';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+/**
+ * Send a push notification for a given alert to a FCM topic.
+ */
+export async function sendAlertNotification(alert: Alert, topic: string) {
+  await admin.messaging().send({
+    topic,
+    notification: {
+      title: alert.headline,
+      body: alert.description ?? '',
+    },
+    data: {
+      id: alert.id,
+      url: alert.url,
+      source: alert.source,
+      severity: alert.severity,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- implement normalized adapters for Polisen events, SMHI warnings, and Krisinformation news/VMAS
- add SCB PxWeb and ArcGIS adapters for region codes and polygons
- aggregate sources into unified alert feed and document external data providers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6895cc87479c832486de488fab7faf86