### PR TITLE
Deploy backend to Oracle Cloud using Terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,19 @@ jobs:
           context: ./backend
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/nord-alert-backend:latest
-      - name: Set up Flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@v1
-      - name: Deploy to Fly.io
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+      - name: Terraform Init
+        working-directory: terraform
+        run: terraform init
+      - name: Terraform Apply
+        working-directory: terraform
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: |
-          flyctl deploy --config fly.toml --image ${{ secrets.DOCKERHUB_USERNAME }}/nord-alert-backend:latest --remote-only
+          TF_VAR_tenancy_ocid: ${{ secrets.OCI_TENANCY_OCID }}
+          TF_VAR_user_ocid: ${{ secrets.OCI_USER_OCID }}
+          TF_VAR_fingerprint: ${{ secrets.OCI_FINGERPRINT }}
+          TF_VAR_private_key: ${{ secrets.OCI_PRIVATE_KEY }}
+          TF_VAR_region: ${{ secrets.OCI_REGION }}
+          TF_VAR_compartment_ocid: ${{ secrets.OCI_COMPARTMENT_OCID }}
+          TF_VAR_image: ${{ secrets.DOCKERHUB_USERNAME }}/nord-alert-backend:latest
+        run: terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The backend retrieves information from a number of official Swedish services:
 
 ### Deployment
 
-The repository includes a GitHub Actions workflow that builds the backend Docker image, pushes it to Docker Hub, and deploys it to Fly.io on every push to `main`. Configure the following secrets in your repository settings:
+The repository includes a GitHub Actions workflow that builds the backend Docker image, pushes it to Docker Hub, and uses Terraform to deploy it to Oracle Cloud on every push to `main`. Configure the following secrets in your repository settings:
 
 - `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for Docker Hub access.
-- `FLY_API_TOKEN` for Fly.io deployments.
+- `OCI_TENANCY_OCID`, `OCI_USER_OCID`, `OCI_FINGERPRINT`, `OCI_PRIVATE_KEY`, `OCI_REGION`, and `OCI_COMPARTMENT_OCID` for Oracle Cloud deployments.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "oci" {
+  tenancy_ocid  = var.tenancy_ocid
+  user_ocid     = var.user_ocid
+  fingerprint   = var.fingerprint
+  private_key   = var.private_key
+  region        = var.region
+}
+
+resource "oci_container_instances_container_instance" "app" {
+  compartment_id = var.compartment_ocid
+  display_name   = "nord-alert"
+
+  containers {
+    name      = "nord-alert-backend"
+    image_url = var.image
+
+    resource_config {
+      memory_limit_in_gbs = 1
+      vcpus_limit         = 1
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,7 @@
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key" {}
+variable "region" {}
+variable "compartment_ocid" {}
+variable "image" {}


### PR DESCRIPTION
## Summary
- deploy workflow now runs Terraform against Oracle Cloud using OCI secrets
- document Terraform deployment and required Oracle Cloud secrets
- add Terraform configuration for container instance

## Testing
- `cd backend && npm run build`
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://releases.hashicorp.com/...` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_b_6895e5f73ec4832489efe3d44811c6fe