### PR TITLE
feat(terraform): auto-discover region resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,5 @@ jobs:
           TF_VAR_private_key: ${{ secrets.OCI_PRIVATE_KEY }}
           TF_VAR_region: ${{ secrets.OCI_REGION }}
           TF_VAR_compartment_ocid: ${{ secrets.OCI_COMPARTMENT_OCID }}
-          TF_VAR_availability_domain: ${{ secrets.OCI_AVAILABILITY_DOMAIN }}
-          TF_VAR_subnet_ocid: ${{ secrets.OCI_SUBNET_OCID }}
           TF_VAR_image: ${{ secrets.DOCKERHUB_USERNAME }}/nord-alert-backend:latest
         run: terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ The backend retrieves information from a number of official Swedish services:
 The repository includes a GitHub Actions workflow that builds the backend Docker image, pushes it to Docker Hub, and uses Terraform to deploy it to Oracle Cloud on every push to `main`. Configure the following secrets in your repository settings:
 
 - `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for Docker Hub access.
-- `OCI_TENANCY_OCID`, `OCI_USER_OCID`, `OCI_FINGERPRINT`, `OCI_PRIVATE_KEY`, `OCI_REGION`, `OCI_COMPARTMENT_OCID`, `OCI_AVAILABILITY_DOMAIN`, and `OCI_SUBNET_OCID` for Oracle Cloud deployments.
+- `OCI_TENANCY_OCID`, `OCI_USER_OCID`, `OCI_FINGERPRINT`, `OCI_PRIVATE_KEY`, `OCI_REGION`, and `OCI_COMPARTMENT_OCID` for Oracle Cloud deployments. Terraform automatically determines the availability domain and subnet.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,8 +16,21 @@ provider "oci" {
   region        = var.region
 }
 
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = var.tenancy_ocid
+}
+
+data "oci_core_vcns" "vcns" {
+  compartment_id = var.compartment_ocid
+}
+
+data "oci_core_subnets" "selected" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = data.oci_core_vcns.vcns.virtual_networks[0].id
+}
+
 resource "oci_container_instances_container_instance" "app" {
-  availability_domain = var.availability_domain
+  availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
   compartment_id       = var.compartment_ocid
   display_name         = "nord-alert"
   shape                = var.shape
@@ -29,7 +42,7 @@ resource "oci_container_instances_container_instance" "app" {
 
   vnics {
     is_public_ip_enabled = true
-    subnet_id            = var.subnet_ocid
+    subnet_id            = data.oci_core_subnets.selected.subnets[0].id
   }
 
   containers {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,8 +5,6 @@ variable "private_key" {}
 variable "region" {}
 variable "compartment_ocid" {}
 variable "image" {}
-variable "availability_domain" {}
-variable "subnet_ocid" {}
 variable "shape" {
   default = "CI.Standard.A1.Flex"
 }


### PR DESCRIPTION
## Summary
- remove need to pass availability domain and subnet OCID
- look up AD, VCN, and subnet data based on region
- simplify deploy workflow and docs

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6895f3b4e7888324be45b715a9c16420