### PR TITLE
Use SSH public key secret in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,4 +54,5 @@ jobs:
           TF_VAR_region: ${{ secrets.OCI_REGION }}
           TF_VAR_compartment_ocid: ${{ secrets.OCI_COMPARTMENT_OCID }}
           TF_VAR_image: ${{ secrets.DOCKERHUB_USERNAME }}/nord-alert-backend:latest
+          TF_VAR_ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
         run: terraform apply -auto-approve


### PR DESCRIPTION
## Summary
- expose SSH public key secret to Terraform during deploy workflow

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68961ef2f7f88324b568ac38619c90a9