### PR TITLE
Avoid instance recreation on repeated Terraform apply

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -152,4 +152,14 @@ resource "oci_core_instance" "vm" {
   }
 
   preserve_boot_volume = false
+
+  lifecycle {
+    # Avoid recreation when the latest image ID changes or when
+    # OCI normalizes user_data on the instance. This keeps the
+    # instance in place on repeated terraform apply runs.
+    ignore_changes = [
+      source_details[0].source_id,
+      metadata["user_data"],
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- prevent `oci_core_instance` from being recreated on each Terraform apply by ignoring image and user_data changes

## Testing
- `terraform fmt terraform/main.tf terraform/variables.tf terraform/outputs.tf` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `apt-get install -y terraform` *(fails: package not found)*
- `terraform validate terraform` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689713716c048324ab8527af6b92384d