### PR TITLE
feat: handle new smhi warning format

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The API exposes a `/alerts` endpoint which accepts optional `county` and `severi
 The backend retrieves information from a number of official Swedish services:
 
 - **Polisen events** – https://polisen.se/api/events
-- **SMHI impact-based warnings** – https://opendata-download-warnings.smhi.se/ibww/api/version/1/warning.json
+- **SMHI impact-based warnings** – https://opendata-download-warnings.smhi.se/warnings/objects
 - **Krisinformation** – https://api.krisinformation.se/v3/news and https://api.krisinformation.se/v3/vmas
 - **SCB PxWeb** – region lists (county and municipality codes/names)
 - **County Administrative Boards ArcGIS** – GeoJSON polygons for counties and municipalities

--- a/backend/src/adapters/smhi.ts
+++ b/backend/src/adapters/smhi.ts
@@ -17,41 +17,49 @@ export interface SmhiWarning {
  */
 export async function fetchSmhiWarnings(): Promise<SmhiWarning[]> {
   const { body } = await request(
-    'https://opendata-download-warnings.smhi.se/ibww/api/version/1/warning.json'
+    'https://opendata-download-warnings.smhi.se/warnings/objects'
   );
-  const data = (await body.json()) as any;
-  const warnings = data?.warnings ?? [];
-  return warnings.map((w: any) => {
-    const levelStr = (
-      w.level ??
-      w.severity ??
-      w.significance ??
-      w.awareness_level ??
-      ''
-    )
-      .toString()
-      .toLowerCase();
+  const data = (await body.json()) as any[];
+  const warnings: SmhiWarning[] = [];
 
-    return {
-      source: 'smhi',
-      id: w.id ?? w.identifier ?? w.eventId ?? '',
-      eventType:
-        w.eventType ?? w.event?.event_type ?? w.event?.text ?? w.event ?? '',
-      level: (['yellow', 'orange', 'red'].includes(levelStr)
-        ? levelStr
-        : 'yellow') as 'yellow' | 'orange' | 'red',
-      description:
-        w.description ?? w.information?.description ?? w.message ?? '',
-      areas: (w.areas ?? w.area ?? w.regions ?? []).map(
-        (a: any) => a.area ?? a.name ?? a.region ?? a
-      ),
-      validFrom: new Date(
-        w.start ?? w.validFrom ?? w.valid_from ?? w.onset ?? w.from
-      ),
-      validTo: new Date(
-        w.end ?? w.validTo ?? w.valid_to ?? w.expires ?? w.to
-      ),
-      url: w.urls?.[0]?.url ?? w.url ?? w.links?.[0]?.href ?? '',
-    };
-  });
+  for (const w of data ?? []) {
+    const eventType = w.event?.en ?? w.event?.sv ?? w.event?.code ?? '';
+
+    for (const area of w.warningAreas ?? []) {
+      const levelCode = (area.warningLevel?.code ?? '')
+        .toString()
+        .toLowerCase();
+      let level: 'yellow' | 'orange' | 'red' = 'yellow';
+      if (['yellow', 'orange', 'red'].includes(levelCode)) {
+        level = levelCode as 'yellow' | 'orange' | 'red';
+      } else if (levelCode === 'message') {
+        level = 'yellow';
+      }
+
+      const description = (area.descriptions ?? [])
+        .map((d: any) => d.text?.en ?? d.text?.sv ?? '')
+        .filter(Boolean)
+        .join('\n');
+
+      const areas = (area.affectedAreas ?? [])
+        .map((a: any) => a.en ?? a.sv ?? '')
+        .filter(Boolean);
+
+      warnings.push({
+        source: 'smhi',
+        id: `${w.id}-${area.id}`,
+        eventType,
+        level,
+        description,
+        areas,
+        validFrom: new Date(area.approximateStart ?? area.published ?? w.created),
+        validTo: new Date(
+          area.approximateEnd ?? area.approximateStart ?? area.published ?? w.created
+        ),
+        url: '',
+      });
+    }
+  }
+
+  return warnings;
 }


### PR DESCRIPTION
## Summary
- adapt SMHI adapter to parse new warnings structure
- document new SMHI warnings endpoint

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ac9a95b48324bc35f6f319e678b8