### PR TITLE
Fix OCI internet gateway reference

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,7 +66,7 @@ data "oci_core_internet_gateways" "existing" {
 }
 
 resource "oci_core_internet_gateway" "igw" {
-  count          = length(data.oci_core_internet_gateways.existing) == 0 ? 1 : 0
+  count          = length(data.oci_core_internet_gateways.existing.internet_gateways) == 0 ? 1 : 0
   compartment_id = var.compartment_ocid
   vcn_id         = local.vcn_id
   display_name   = "nord-alert-igw"


### PR DESCRIPTION
## Summary
- fix internet gateway count and lookup to avoid unsupported attribute errors

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b41ba6d08324a3096e4d30b9d386