### PR TITLE
fix: sanitize alerts payload and handle missing fields

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,7 @@
 import Fastify from 'fastify';
 import { z } from 'zod';
 import { fetchAllAlerts } from './services/aggregator';
-import { Severity } from './models/alert';
+import { Severity, Alert } from './models/alert';
 
 const app = Fastify();
 
@@ -11,6 +11,12 @@ const querySchema = z.object({
 });
 
 const severityOrder: Severity[] = ['info', 'low', 'medium', 'high'];
+
+function pruneNulls(alert: Alert): Alert {
+  return Object.fromEntries(
+    Object.entries(alert).filter(([, v]) => v !== null && v !== undefined)
+  ) as Alert;
+}
 
 app.get('/health', async () => {
   return { status: 'ok' };
@@ -29,7 +35,7 @@ app.get('/alerts', async (request, reply) => {
       (a) => severityOrder.indexOf(a.severity) >= threshold
     );
   }
-  return filtered;
+  return filtered.map(pruneNulls);
 });
 
 export async function start() {

--- a/mobile/lib/models/alert.dart
+++ b/mobile/lib/models/alert.dart
@@ -38,8 +38,8 @@ class Alert {
 
   factory Alert.fromJson(Map<String, dynamic> json) {
     return Alert(
-      id: json['id'] as String,
-      source: alertSourceFromString(json['source'] as String),
+      id: (json['id'] ?? '') as String,
+      source: alertSourceFromString((json['source'] as String?) ?? 'polisen'),
       headline: (json['headline'] ?? '') as String,
       description: json['description'] as String?,
       areas: (json['areas'] as List<dynamic>? ?? const []).map((e) => e.toString()).toList(),

--- a/mobile/test/alert_model_test.dart
+++ b/mobile/test/alert_model_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nord_alert_mobile/models/alert.dart';
 
 void main() {
-  test('Alert model parses from JSON', () {
+  test('Alert model parses from JSON', () { 
     final json = {
       'id': 'abc123',
       'source': 'polisen',
@@ -22,6 +22,23 @@ void main() {
     expect(a.areas, ['Stockholm']);
     expect(a.severity, 'info');
     expect(a.url, 'https://example.com');
+  });
+
+  test('Alert model handles missing attributes', () {
+    final json = {
+      'id': 'abc123',
+      'source': 'polisen',
+    };
+
+    final a = Alert.fromJson(json);
+    expect(a.id, 'abc123');
+    expect(a.source, AlertSource.polisen);
+    expect(a.headline, '');
+    expect(a.description, null);
+    expect(a.areas, <String>[]);
+    expect(a.severity, 'info');
+    expect(a.url, '');
+    expect(a.publishedAt, isA<DateTime>());
   });
 }
 


### PR DESCRIPTION
## Summary
- strip null/undefined attributes from `/alerts` responses
- guard mobile `Alert.fromJson` against missing fields
- add test for parsing alerts with absent fields

## Testing
- `cd backend && npm run build`
- `cd mobile && flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68bfe351843483248b7e10c17aea470c